### PR TITLE
Added concurrency to Extractor and DocumentWalker

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,5 +3,4 @@
 2. Add a link between the particular table extractor and the table that is extracted from that extractor
 3. Pull out decision of when to extract as distinct from performing the extraction
 4. Add a numberOfColumns method to the Table class
-5. Review mutability of the DocumentWalker
-6. Add threading
+5. Rename DocumentWalker and class constructors

--- a/src/main/scala/tools/ambitious/pdfextractiontoolkit/extraction/DocumentWalker.scala
+++ b/src/main/scala/tools/ambitious/pdfextractiontoolkit/extraction/DocumentWalker.scala
@@ -1,26 +1,37 @@
 package tools.ambitious.pdfextractiontoolkit.extraction
 
+import scala.concurrent.{Promise, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
 import tools.ambitious.pdfextractiontoolkit.extraction.tableextractors.TableExtractor
 import tools.ambitious.pdfextractiontoolkit.model.{Document, Page, Table}
 
 class DocumentWalker protected (val document:Document, val tableExtractors: Set[TableExtractor]) {
-  val stateBundles: Map[TableExtractor, StateBundle] = tableExtractors.map(_ -> StateBundle.create).toMap
+  private val stateBundles: Map[TableExtractor, StateBundle] = tableExtractors.map(_ -> StateBundle.create).toMap
+  private val promise: Promise[Map[TableExtractor, Table]] = Promise()
 
-  def walk() = {
-    callOnStartOnTableExtractors()
+  private def run() =
+    Future {
+      traverseDocument()
+      promise.success(getCompletedTables)
+    }
 
-    document.pages.foreach(page => callOnPageOnTableExtractors(page))
+  private def traverseDocument() = {
+      callOnStartOnTableExtractors()
 
-    callOnEndOnTableExtractors()
+      document.pages.foreach(page => callOnPageOnTableExtractors(page))
+
+      callOnEndOnTableExtractors()
   }
 
-  def getTables: Map[TableExtractor, Table] = {
+  private def getCompletedTables: Map[TableExtractor, Table] =
     tableExtractors
       .map(tableExtractor => tableExtractor -> tableExtractor.tableFromState(stateBundles(tableExtractor)))
       .filter((tuple: (TableExtractor, Option[Table])) => tuple._2.isDefined)
       .map((tuple: (TableExtractor, Option[Table])) => tuple._1 -> tuple._2.get)
       .toMap
-  }
+
+  def getTables: Future[Map[TableExtractor, Table]] =
+    promise.future
 
   private def callOnStartOnTableExtractors() =
     tableExtractors.foreach(tableExtractor => tableExtractor.onStart(stateBundles(tableExtractor)))
@@ -33,8 +44,11 @@ class DocumentWalker protected (val document:Document, val tableExtractors: Set[
 }
 
 object DocumentWalker {
-  def toWalkWithTableExtractors(document: Document, tableExtractors: Set[TableExtractor]): DocumentWalker =
-    new DocumentWalker(document, tableExtractors)
+  def toWalkWithTableExtractors(document: Document, tableExtractors: Set[TableExtractor]): DocumentWalker = {
+    val walker = new DocumentWalker(document, tableExtractors)
+    walker.run()
+    walker
+  }
 
   def toWalkWithTableExtractors(document: Document, tableExtractors: Seq[TableExtractor]): DocumentWalker =
     toWalkWithTableExtractors(document, tableExtractors.toSet)

--- a/src/main/scala/tools/ambitious/pdfextractiontoolkit/extraction/Extractor.scala
+++ b/src/main/scala/tools/ambitious/pdfextractiontoolkit/extraction/Extractor.scala
@@ -10,7 +10,7 @@ class Extractor protected(private val document: Document, private val extractors
 
     walker.walk()
 
-    walker.getTables.values.flatten.toList
+    walker.getTables.values.toList
   }
 }
 

--- a/src/main/scala/tools/ambitious/pdfextractiontoolkit/extraction/Extractor.scala
+++ b/src/main/scala/tools/ambitious/pdfextractiontoolkit/extraction/Extractor.scala
@@ -2,15 +2,19 @@ package tools.ambitious.pdfextractiontoolkit.extraction
 
 import tools.ambitious.pdfextractiontoolkit.extraction.tableextractors.TableExtractor
 import tools.ambitious.pdfextractiontoolkit.model._
+import scala.concurrent.{Promise, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class Extractor protected(private val document: Document, private val extractors: List[TableExtractor]) {
 
-  def extractTables: List[Table] = {
+  def extractTables: Future[List[Table]] = {
     val walker: DocumentWalker = DocumentWalker.toWalkWithTableExtractors(document, extractors)
 
-    walker.walk()
-
-    walker.getTables.values.toList
+    val promise: Promise[List[Table]] = Promise()
+    walker.getTables.onSuccess {
+      case tables => promise.success(tables.values.toList)
+    }
+    promise.future
   }
 }
 

--- a/src/test/scala/tools/ambitious/pdfextractiontoolkit/extraction/ExtractorSpec.scala
+++ b/src/test/scala/tools/ambitious/pdfextractiontoolkit/extraction/ExtractorSpec.scala
@@ -5,6 +5,8 @@ import tools.ambitious.pdfextractiontoolkit.extraction.tableextractors.{FirstOcc
 import tools.ambitious.pdfextractiontoolkit.model.geometry.{PositivePoint, Rectangle, Size}
 import tools.ambitious.pdfextractiontoolkit.model.{Document, Table}
 import tools.ambitious.pdfextractiontoolkit.util.CSVUtil
+import scala.concurrent.Await
+import scala.concurrent.duration._
 
 class ExtractorSpec extends FreeSpec {
   s"An ${Extractor.getClass.getSimpleName} with a document and a ${PageNumberTableExtractor.getClass.getSimpleName}" - {
@@ -16,7 +18,7 @@ class ExtractorSpec extends FreeSpec {
     val extractor: Extractor = Extractor.fromDocumentAndExtractors(document, tableExtractor)
 
     "should be able to extract the table and have it match the values from it's corresponding CSV file" in {
-      val tables: List[Table] = extractor.extractTables
+      val tables: List[Table] = Await.result(extractor.extractTables, 60.seconds)
 
       document.close()
 
@@ -37,8 +39,9 @@ class ExtractorSpec extends FreeSpec {
     val extractor: Extractor = Extractor.fromDocumentAndExtractors(document, tableExtractor)
 
     "should be able to extract the table and have it match the values from it's corresponding CSV file" in {
+      val tables: List[Table] = Await.result(extractor.extractTables, 60.seconds)
 
-      val tables: List[Table] = extractor.extractTables
+      document.close()
 
       val table: Table = tables.head
       val tableFromCSV: Table = CSVUtil.tableFromURL(simpleTest2Tables2TitlePage2CSVURL)

--- a/src/test/scala/tools/ambitious/pdfextractiontoolkit/extraction/tableextractors/FirstOccurrenceOfStringTableExtractorSpec.scala
+++ b/src/test/scala/tools/ambitious/pdfextractiontoolkit/extraction/tableextractors/FirstOccurrenceOfStringTableExtractorSpec.scala
@@ -5,6 +5,8 @@ import tools.ambitious.pdfextractiontoolkit.extraction._
 import tools.ambitious.pdfextractiontoolkit.model.geometry.{PositivePoint, Rectangle, Size}
 import tools.ambitious.pdfextractiontoolkit.model.{Document, Table}
 import tools.ambitious.pdfextractiontoolkit.util.CSVUtil
+import scala.concurrent.Await
+import scala.concurrent.duration._
 
 class FirstOccurrenceOfStringTableExtractorSpec extends FreeSpec {
   val simpleTest2Tables2TitleURL = getClass.getResource("/simplePDFs/SimpleTest2Tables1Title.pdf")
@@ -18,10 +20,10 @@ class FirstOccurrenceOfStringTableExtractorSpec extends FreeSpec {
     "when put through a walker with test document SimpleTest2Tables1Title.pdf" - {
       val document: Document = Document.fromPDFPath(simpleTest2Tables2TitleURL)
       val walker: DocumentWalker = DocumentWalker.toWalkWithTableExtractor(document, tableExtractor)
-      walker.walk()
+      val tables: Map[TableExtractor, Table] = Await.result(walker.getTables, 60.seconds)
 
       "should return the table at page 2" in {
-        val table: Option[Table] = walker.getTables.get(tableExtractor)
+        val table: Option[Table] = tables.get(tableExtractor)
         val tableFromCSV: Table = CSVUtil.tableFromURL(simpleTest2Tables2TitlePage2CSVURL)
 
         assert(table.get == tableFromCSV)

--- a/src/test/scala/tools/ambitious/pdfextractiontoolkit/extraction/tableextractors/FirstOccurrenceOfStringTableExtractorSpec.scala
+++ b/src/test/scala/tools/ambitious/pdfextractiontoolkit/extraction/tableextractors/FirstOccurrenceOfStringTableExtractorSpec.scala
@@ -21,10 +21,10 @@ class FirstOccurrenceOfStringTableExtractorSpec extends FreeSpec {
       walker.walk()
 
       "should return the table at page 2" in {
-        val table: Table = walker.getTables(tableExtractor).get
+        val table: Option[Table] = walker.getTables.get(tableExtractor)
         val tableFromCSV: Table = CSVUtil.tableFromURL(simpleTest2Tables2TitlePage2CSVURL)
 
-        assert(table == tableFromCSV)
+        assert(table.get == tableFromCSV)
       }
     }
   }

--- a/src/test/scala/tools/ambitious/pdfextractiontoolkit/extraction/tableextractors/PageNumberTableExtractorSpec.scala
+++ b/src/test/scala/tools/ambitious/pdfextractiontoolkit/extraction/tableextractors/PageNumberTableExtractorSpec.scala
@@ -20,10 +20,10 @@ class PageNumberTableExtractorSpec extends FreeSpec {
         walker.walk()
 
         "should return the table at page 2" in {
-          val table: Table = walker.getTables(tableExtractor).get
+          val table: Option[Table] = walker.getTables.get(tableExtractor)
           val tableFromCSV: Table = CSVUtil.tableFromURL(simpleTest2Tables2TitlePage2CSVURL)
 
-          assert(table == tableFromCSV)
+          assert(table.get == tableFromCSV)
         }
       }
     }
@@ -38,7 +38,7 @@ class PageNumberTableExtractorSpec extends FreeSpec {
         walker.walk()
 
         "should return the two tables merged" in {
-          val table: Table = walker.getTables(tableExtractor).get
+          val table: Option[Table] = walker.getTables.get(tableExtractor)
 
           val tableMerger: SimpleTableMerger = SimpleTableMerger.create
 
@@ -48,7 +48,7 @@ class PageNumberTableExtractorSpec extends FreeSpec {
 
           val tableFromCSV: Table = tableMerger.mergeTables(tables).get
 
-          assert(table == tableFromCSV)
+          assert(table.get == tableFromCSV)
         }
       }
     }

--- a/src/test/scala/tools/ambitious/pdfextractiontoolkit/extraction/tableextractors/PageNumberTableExtractorSpec.scala
+++ b/src/test/scala/tools/ambitious/pdfextractiontoolkit/extraction/tableextractors/PageNumberTableExtractorSpec.scala
@@ -6,6 +6,8 @@ import tools.ambitious.pdfextractiontoolkit.extraction.tablemergers.SimpleTableM
 import tools.ambitious.pdfextractiontoolkit.model.geometry.{PositivePoint, Rectangle, Size}
 import tools.ambitious.pdfextractiontoolkit.model.{Document, Table}
 import tools.ambitious.pdfextractiontoolkit.util.CSVUtil
+import scala.concurrent.Await
+import scala.concurrent.duration._
 
 class PageNumberTableExtractorSpec extends FreeSpec {
   val region: Rectangle = Rectangle.fromCornerAndSize(PositivePoint.at(168.48, 240), Size.fromWidthAndHeight(213.54, 340))
@@ -17,10 +19,10 @@ class PageNumberTableExtractorSpec extends FreeSpec {
       "when put through a walker with test document 2" - {
         val document: Document = Document.fromPDFPath(simpleTest2Tables2TitleURL)
         val walker: DocumentWalker = DocumentWalker.toWalkWithTableExtractor(document, tableExtractor)
-        walker.walk()
+        val tables: Map[TableExtractor, Table] = Await.result(walker.getTables, 60.seconds)
 
         "should return the table at page 2" in {
-          val table: Option[Table] = walker.getTables.get(tableExtractor)
+          val table: Option[Table] = tables.get(tableExtractor)
           val tableFromCSV: Table = CSVUtil.tableFromURL(simpleTest2Tables2TitlePage2CSVURL)
 
           assert(table.get == tableFromCSV)
@@ -35,18 +37,18 @@ class PageNumberTableExtractorSpec extends FreeSpec {
       "when put through a walker with test document 2" - {
         val document: Document = Document.fromPDFPath(simpleTest2Tables2TitleURL)
         val walker: DocumentWalker = DocumentWalker.toWalkWithTableExtractor(document, tableExtractor)
-        walker.walk()
+        val tables: Map[TableExtractor, Table] = Await.result(walker.getTables, 60.seconds)
 
         "should return the two tables merged" in {
-          val table: Option[Table] = walker.getTables.get(tableExtractor)
+          val table: Option[Table] = tables.get(tableExtractor)
 
           val tableMerger: SimpleTableMerger = SimpleTableMerger.create
 
           val table1: Table = CSVUtil.tableFromURL(simpleTest2Tables2TitlePage1CSVURL)
           val table2: Table = CSVUtil.tableFromURL(simpleTest2Tables2TitlePage2CSVURL)
-          val tables: List[Table] = List(table1, table2)
+          val tablesToMerge: List[Table] = List(table1, table2)
 
-          val tableFromCSV: Table = tableMerger.mergeTables(tables).get
+          val tableFromCSV: Table = tableMerger.mergeTables(tablesToMerge).get
 
           assert(table.get == tableFromCSV)
         }

--- a/src/test/scala/tools/ambitious/pdfextractiontoolkit/realworldtests/expensereports/SummaryOfParliamentaryExpenditureByPeriodExtractionSpec.scala
+++ b/src/test/scala/tools/ambitious/pdfextractiontoolkit/realworldtests/expensereports/SummaryOfParliamentaryExpenditureByPeriodExtractionSpec.scala
@@ -5,6 +5,8 @@ import tools.ambitious.pdfextractiontoolkit.extraction.Extractor
 import tools.ambitious.pdfextractiontoolkit.extraction.tableextractors.FirstOccurrenceOfStringTableExtractor
 import tools.ambitious.pdfextractiontoolkit.model.{Table, Document}
 import tools.ambitious.pdfextractiontoolkit.model.geometry.{Size, PositivePoint, Rectangle}
+import scala.concurrent.Await
+import scala.concurrent.duration._
 
 class SummaryOfParliamentaryExpenditureByPeriodExtractionSpec extends FreeSpec {
 
@@ -20,7 +22,7 @@ class SummaryOfParliamentaryExpenditureByPeriodExtractionSpec extends FreeSpec {
 
       val extractor = Extractor.fromDocumentAndExtractors(document, tableExtractor)
 
-      val tables: List[Table] = extractor.extractTables
+      val tables: List[Table] = Await.result(extractor.extractTables, 60.seconds)
 
       "should return a single table" in {
         assert(tables.length == 1)


### PR DESCRIPTION
 - Extractor now returns a Future
 - DocumentWalker no longer requires a manual walk
 - DocumentWalker's getTables method now returns a Future[Map[TableExtractor, Table]]
 - Updated TODO
 - Updated specs